### PR TITLE
Add brew path to TrailDB

### DIFF
--- a/native/mac/pom.xml
+++ b/native/mac/pom.xml
@@ -62,7 +62,7 @@
 				</sources>
 
 				<compilerStartOptions>
-				<compilerStartOption></compilerStartOption>
+				<compilerStartOption>-I/usr/local/Cellar/traildb/0.6/include</compilerStartOption>
 				</compilerStartOptions>
 
 				<linkerStartOptions>


### PR DESCRIPTION
* Link to `usr/local/Cellar/traildb/0.6/include` for brew installations.