### PR TITLE
Field struct refactor

### DIFF
--- a/java/src/main/java/traildb/TrailDBMultiTrail.java
+++ b/java/src/main/java/traildb/TrailDBMultiTrail.java
@@ -1,17 +1,8 @@
 package traildb;
 
 public class TrailDBMultiTrail {
-	public long cursorIndex;
 
-	private long timestamp;
-
-	private long numItems;
-
-	private long items;
-
-	private long cur;
-
-	private long db;
+	private long fields;
 
 	public TrailDBMultiTrail(TrailDBTrail[] trails) {
 		init(trails);
@@ -24,14 +15,15 @@ public class TrailDBMultiTrail {
 	 * @param i index of item to get
 	 * @return The item value
 	 */
-	public String getItem(int i) {
-		if (i >= numItems || i < 0) {
-			throw new IndexOutOfBoundsException("getItem(" + i + ") but numItems in event is " + numItems);
-		}
-		return native_getItem(i);
-	}
+	public native String getItem(int i);
 
-	private native String native_getItem(int i);
+	/**
+	 * Get number of items the event has
+	 * @return number of items
+	 */
+	public native int getNumItems();
+
+	public native long getTimestamp();
 
 	public native void free();
 
@@ -42,20 +34,6 @@ public class TrailDBMultiTrail {
 	public native TrailDBMultiTrail[] nextBatch(int maxEvents);
 
 	public native TrailDBMultiTrail peek();
-
-	public long getTimestamp() {
-		if (items == 0) {
-			// throw new IllegalStateException("Cursor is not pointing at an event");
-		}
-		return timestamp;
-	}
-
-	public long getNumItems() {
-		if (items == 0) {
-			// throw new IllegalStateException("Cursor is not pointing at an event");
-		}
-		return numItems;
-	}
 
 	private static native void initIDs();
 

--- a/java/src/main/java/traildb/TrailDBTrail.java
+++ b/java/src/main/java/traildb/TrailDBTrail.java
@@ -2,17 +2,8 @@ package traildb;
 
 import traildb.filters.TrailDBEventFilter;
 
-public class TrailDBTrail
-{
-	private long timestamp;
-
-	private long numItems;
-
-	private long items;
-
-	private long db;
-
-	private long cur;
+public class TrailDBTrail {
+	private long fields;
 
 	private long currentTrail;
 
@@ -31,16 +22,18 @@ public class TrailDBTrail
 	 * @param i index of item to get
 	 * @return The item value
 	 */
-	public String getItem(int i) {
-		if (i >= numItems || i < 0) {
-			throw new IndexOutOfBoundsException("getItem(" + i + ") but numItems in event is " + numItems);
-		}
-		return native_getItem(i);
-	}
+	public native String getItem(int i);
 
-	private native String native_getItem(int i);
+	/**
+	 * Get number of items the event has
+	 * @return number of items
+	 */
+	public native int getNumItems();
+
+	public native long getTimestamp();
 
 	public String[] getItems() {
+		int numItems = getNumItems();
 		String[] output = new String[(int) numItems];
 		for (long i = 0; i < numItems; i++) {
 			output[(int) i] = getItem((int) i);
@@ -91,24 +84,6 @@ public class TrailDBTrail
 	public native TrailDBTrail next();
 
 	public native TrailDBTrail peek();
-
-	public long getTimestamp() {
-		if (items == 0) {
-			throw new IllegalStateException("Cursor is not pointing at an event");
-		}
-		return timestamp;
-	}
-
-	/**
-	 * Get number of items the event has
-	 * @return number of items
-	 */
-	public long getNumItems() {
-		if (items == 0) {
-			throw new IllegalStateException("Cursor is not pointing at an event");
-		}
-		return numItems;
-	}
 
 	private static native void initIDs();
 

--- a/native/src/main/native/TrailDBMultiTrail.c
+++ b/native/src/main/native/TrailDBMultiTrail.c
@@ -1,73 +1,88 @@
 #include <traildb.h>
 #include <string.h>
 #include "traildb-java.h"
+#include "traildb-java-static.h"
 
-jfieldID FID_traildb_TrailDBMultiTrail_cur;
+jfieldID FID_traildb_TrailDBMultiTrail_fields;
 
-jfieldID FID_traildb_TrailDBMultiTrail_timestamp;
-
-jfieldID FID_traildb_TrailDBMultiTrail_numItems;
-
-jfieldID FID_traildb_TrailDBMultiTrail_items;
-
-jfieldID FID_traildb_TrailDBMultiTrail_db;
-
-jfieldID FID_traildb_TrailDBMultiTrail_cursorIndex;
-
-jfieldID FID_traildb_TrailDBTrail_cur;
-
+jfieldID FID_traildb_TrailDBTrail_fields;
 
 /*
  * Class:     traildb_TrailDBMultiTrail
  * Method:    init
  * Signature: ([Ltraildb/TrailDBTrail;)V
  */
-JNIEXPORT void JNICALL Java_traildb_TrailDBMultiTrail_init(JNIEnv *env, jobject obj, jobjectArray cursors) {
-	jobject cursor_obj;
+JNIEXPORT void JNICALL Java_traildb_TrailDBMultiTrail_init(JNIEnv *env, jobject obj, jobjectArray trails) {
+	jobject trail_obj;
+	TrailDBMultiTrailFields *fields = malloc(sizeof(TrailDBMultiTrailFields));
+	TrailDBTrailFields *trail_fields;
 
 	tdb_multi_cursor *multi_cur;
 	tdb_cursor **tgt_cursors;
 
-	int num_cursors = (*env)->GetArrayLength(env, cursors);
+	int num_cursors = (*env)->GetArrayLength(env, trails);
 
 	tgt_cursors = malloc(num_cursors * sizeof(tdb_cursor *));
 
 	for (int i = 0; i < num_cursors; i++) {
-		cursor_obj = (*env)->GetObjectArrayElement(env, cursors, i);
-		tgt_cursors[i] = (tdb_cursor *) (*env)->GetLongField(env, cursor_obj, FID_traildb_TrailDBTrail_cur);
+		trail_obj = (*env)->GetObjectArrayElement(env, trails, i);
+		trail_fields = (TrailDBTrailFields *) (*env)->GetLongField(env, trail_obj, FID_traildb_TrailDBTrail_fields);
+		tgt_cursors[i] = (tdb_cursor *) trail_fields->cur;
 	}
 
 	multi_cur = tdb_multi_cursor_new(tgt_cursors, num_cursors);
 
-	// free tgt_cursors;
-
-	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_cur, (long) multi_cur);
-
 	// Initialize items to NULL because we haven't called next yet
 
-	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_items, 0L);
-}
+	fields->multi_cur = (long) multi_cur;
+	fields->items = 0L;
 
+	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_fields, (long) fields);
+}
 
 /*
  * Class:     traildb_TrailDBMultiTrail
  * Method:    native_getItem
  * Signature: (I)Ljava/lang/String;
  */
-JNIEXPORT jstring JNICALL Java_traildb_TrailDBMultiTrail_native_1getItem(JNIEnv *env, jobject obj, jint index) {
+JNIEXPORT jstring JNICALL Java_traildb_TrailDBMultiTrail_getItem(JNIEnv *env, jobject obj, jint index) {
+	jclass exc;
+
     const tdb *db;
 	const tdb_item *items;
 	const char *value;
 	char *tgt_value;
 	uint64_t value_length;
 
-	// Retrieve items pointer
+	TrailDBMultiTrailFields *fields;
 
-	items = (tdb_item *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_items);
+	// Retrieve fields pointer
 
-	// Retrieve db pointer
+	fields = (TrailDBMultiTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_fields);
 
-	db = (tdb *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_db);
+	items = (tdb_item *) fields->items;
+
+    if (items == 0L) {
+		exc = (*env)->FindClass(env, "java/lang/IllegalStateException");
+		if (exc == NULL) {
+			/* Could not find the exception - We are in so much trouble right now */
+			exit(1);
+		}
+		(*env)->ThrowNew(env, exc, "Cursor is not pointing at an event");
+		return NULL;
+    }
+
+	if (index >= fields->num_items || index < 0) {
+		exc = (*env)->FindClass(env, "java/lang/IndexOutOfBoundsException");
+		if (exc == NULL) {
+			/* Could not find the exception - We are in so much trouble right now */
+			exit(1);
+		}
+		(*env)->ThrowNew(env, exc, "getItem out of bounds");
+		return NULL;
+	}
+
+	db = (tdb *) fields->db;
 
 	// Get the value of the item
 
@@ -82,6 +97,60 @@ JNIEXPORT jstring JNICALL Java_traildb_TrailDBMultiTrail_native_1getItem(JNIEnv 
 	tgt_value[value_length] = '\0';
 
 	return (*env)->NewStringUTF(env, tgt_value);
+}
+
+/*
+ * Class:     traildb_TrailDBMultiTrail
+ * Method:    getNumItems
+ * Signature: ()I
+ */
+JNIEXPORT jint JNICALL Java_traildb_TrailDBMultiTrail_getNumItems(JNIEnv *env, jobject obj) {
+	jclass exc;
+
+	TrailDBMultiTrailFields *fields;
+
+	// Retrieve fields pointer
+
+    fields = (TrailDBMultiTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_fields);
+
+    if (fields->items == 0L) {
+		exc = (*env)->FindClass(env, "java/lang/IllegalStateException");
+		if (exc == NULL) {
+			/* Could not find the exception - We are in so much trouble right now */
+			exit(1);
+		}
+		(*env)->ThrowNew(env, exc, "Cursor is not pointing at an event");
+		return 0;
+    }
+
+    return fields->num_items;
+}
+
+/*
+ * Class:     traildb_TrailDBMultiTrail
+ * Method:    getTimestamp
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_traildb_TrailDBMultiTrail_getTimestamp(JNIEnv *env, jobject obj) {
+	jclass exc;
+
+	TrailDBMultiTrailFields *fields;
+
+	// Retrieve fields pointer
+
+    fields = (TrailDBMultiTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_fields);
+
+    if (fields->items == 0L) {
+		exc = (*env)->FindClass(env, "java/lang/IllegalStateException");
+		if (exc == NULL) {
+			/* Could not find the exception - We are in so much trouble right now */
+			exit(1);
+		}
+		(*env)->ThrowNew(env, exc, "Cursor is not pointing at an event");
+		return 0;
+    }
+
+    return fields->timestamp;
 }
 
 /*
@@ -108,48 +177,39 @@ JNIEXPORT void JNICALL Java_traildb_TrailDBMultiTrail_reset(JNIEnv *env, jobject
  * Signature: ()Ltraildb/TrailDBMultiTrail;
  */
 JNIEXPORT jobject JNICALL Java_traildb_TrailDBMultiTrail_next(JNIEnv *env, jobject obj) {
-
 	tdb_multi_cursor *multi_cur;
 	const tdb_multi_event *multi_event;
 	const tdb_event *event;
 
+	TrailDBMultiTrailFields *fields;
+
+	// Retrieve fields pointer
+
+	fields = (TrailDBMultiTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_fields);
+
 	// Get cur pointer
 
-	multi_cur = (tdb_multi_cursor *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_cur);
+	multi_cur = (tdb_multi_cursor *) fields->multi_cur;
 
 	// Call multi cursor next
 
 	multi_event = tdb_multi_cursor_next(multi_cur);
 
 	if (multi_event == NULL) {
-		(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_timestamp, 0L);
-		(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_numItems, 0L);
-		(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_items, 0L);
+		fields->timestamp = 0L;
+		fields->num_items = 0L;
+		fields->items = 0L;
 
 		return NULL;
 	}
 
 	event = multi_event->event;
 
-	// Store timestamp
-
-	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_timestamp, (long) event->timestamp);
-
-	// Store number of items
-
-	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_numItems, (long) event->num_items);
-
-	// Store items pointer
-
-	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_items, (long) event->items);
-
-	// Store db pointer
-
-	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_db, (long) multi_event->db);
-
-	// Store cursor index
-
-	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_cursorIndex, (long) multi_event->cursor_idx);
+	fields->timestamp = (long) event->timestamp;
+	fields->num_items = (long) event->num_items;
+	fields->items = (long) event->items;
+	fields->db = (long) multi_event->db;
+	fields->cursor_idx = (long) multi_event->cursor_idx;
 
 	return obj;
 }
@@ -173,43 +233,35 @@ JNIEXPORT jobject JNICALL Java_traildb_TrailDBMultiTrail_peek(JNIEnv *env, jobje
 	const tdb_multi_event *multi_event;
 	const tdb_event *event;
 
+	TrailDBMultiTrailFields *fields;
+
+	// Retrieve fields pointer
+
+	fields = (TrailDBMultiTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_fields);
+
 	// Get cur pointer
 
-	multi_cur = (tdb_multi_cursor *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_cur);
+	multi_cur = (tdb_multi_cursor *) fields->multi_cur;
 
 	// Call multi cursor next
 
 	multi_event = tdb_multi_cursor_peek(multi_cur);
 
 	if (multi_event == NULL) {
-		(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_timestamp, 0L);
-		(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_numItems, 0L);
-		(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_items, 0L);
+		fields->timestamp = 0L;
+		fields->num_items = 0L;
+		fields->items = 0L;
 
 		return NULL;
 	}
 
 	event = multi_event->event;
 
-	// Store timestamp
-
-	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_timestamp, (long) event->timestamp);
-
-	// Store number of items
-
-	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_numItems, (long) event->num_items);
-
-	// Store items pointer
-
-	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_items, (long) event->items);
-
-	// Store db pointer
-
-	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_db, (long) multi_event->db);
-
-	// Store cursor index
-
-	(*env)->SetLongField(env, obj, FID_traildb_TrailDBMultiTrail_cursorIndex, (long) multi_event->cursor_idx);
+	fields->timestamp = (long) event->timestamp;
+	fields->num_items = (long) event->num_items;
+	fields->items = (long) event->items;
+	fields->db = (long) multi_event->db;
+	fields->cursor_idx = (long) multi_event->cursor_idx;
 
 	return obj;
 }
@@ -223,17 +275,8 @@ JNIEXPORT void JNICALL Java_traildb_TrailDBMultiTrail_initIDs(JNIEnv *env, jclas
 
 	jclass traildb_TrailDBTrail = (*env)->FindClass(env, "traildb/TrailDBTrail");
 
-	FID_traildb_TrailDBMultiTrail_cur = (*env)->GetFieldID(env, cls, "cur", "J");
+	FID_traildb_TrailDBMultiTrail_fields = (*env)->GetFieldID(env, cls, "fields", "J");
 
-	FID_traildb_TrailDBMultiTrail_timestamp = (*env)->GetFieldID(env, cls, "timestamp", "J");
+	FID_traildb_TrailDBTrail_fields = (*env)->GetFieldID(env, traildb_TrailDBTrail, "fields", "J");
 
-	FID_traildb_TrailDBMultiTrail_numItems = (*env)->GetFieldID(env, cls, "numItems", "J");
-
-	FID_traildb_TrailDBMultiTrail_items = (*env)->GetFieldID(env, cls, "items", "J");
-
-	FID_traildb_TrailDBMultiTrail_db = (*env)->GetFieldID(env, cls, "db", "J");
-
-	FID_traildb_TrailDBMultiTrail_cursorIndex = (*env)->GetFieldID(env, cls, "cursorIndex", "J");
-
-	FID_traildb_TrailDBTrail_cur = (*env)->GetFieldID(env, traildb_TrailDBTrail, "cur", "J");
 }

--- a/native/src/main/native/TrailDBMultiTrail.c
+++ b/native/src/main/native/TrailDBMultiTrail.c
@@ -48,7 +48,7 @@ JNIEXPORT void JNICALL Java_traildb_TrailDBMultiTrail_init(JNIEnv *env, jobject 
 JNIEXPORT jstring JNICALL Java_traildb_TrailDBMultiTrail_getItem(JNIEnv *env, jobject obj, jint index) {
 	jclass exc;
 
-    const tdb *db;
+	const tdb *db;
 	const tdb_item *items;
 	const char *value;
 	char *tgt_value;
@@ -62,7 +62,7 @@ JNIEXPORT jstring JNICALL Java_traildb_TrailDBMultiTrail_getItem(JNIEnv *env, jo
 
 	items = (tdb_item *) fields->items;
 
-    if (items == 0L) {
+	if (items == 0L) {
 		exc = (*env)->FindClass(env, "java/lang/IllegalStateException");
 		if (exc == NULL) {
 			/* Could not find the exception - We are in so much trouble right now */
@@ -70,7 +70,7 @@ JNIEXPORT jstring JNICALL Java_traildb_TrailDBMultiTrail_getItem(JNIEnv *env, jo
 		}
 		(*env)->ThrowNew(env, exc, "Cursor is not pointing at an event");
 		return NULL;
-    }
+	}
 
 	if (index >= fields->num_items || index < 0) {
 		exc = (*env)->FindClass(env, "java/lang/IndexOutOfBoundsException");
@@ -111,9 +111,9 @@ JNIEXPORT jint JNICALL Java_traildb_TrailDBMultiTrail_getNumItems(JNIEnv *env, j
 
 	// Retrieve fields pointer
 
-    fields = (TrailDBMultiTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_fields);
+	fields = (TrailDBMultiTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_fields);
 
-    if (fields->items == 0L) {
+	if (fields->items == 0L) {
 		exc = (*env)->FindClass(env, "java/lang/IllegalStateException");
 		if (exc == NULL) {
 			/* Could not find the exception - We are in so much trouble right now */
@@ -121,9 +121,9 @@ JNIEXPORT jint JNICALL Java_traildb_TrailDBMultiTrail_getNumItems(JNIEnv *env, j
 		}
 		(*env)->ThrowNew(env, exc, "Cursor is not pointing at an event");
 		return 0;
-    }
+	}
 
-    return fields->num_items;
+	return fields->num_items;
 }
 
 /*
@@ -138,9 +138,9 @@ JNIEXPORT jlong JNICALL Java_traildb_TrailDBMultiTrail_getTimestamp(JNIEnv *env,
 
 	// Retrieve fields pointer
 
-    fields = (TrailDBMultiTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_fields);
+	fields = (TrailDBMultiTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBMultiTrail_fields);
 
-    if (fields->items == 0L) {
+	if (fields->items == 0L) {
 		exc = (*env)->FindClass(env, "java/lang/IllegalStateException");
 		if (exc == NULL) {
 			/* Could not find the exception - We are in so much trouble right now */
@@ -148,9 +148,9 @@ JNIEXPORT jlong JNICALL Java_traildb_TrailDBMultiTrail_getTimestamp(JNIEnv *env,
 		}
 		(*env)->ThrowNew(env, exc, "Cursor is not pointing at an event");
 		return 0;
-    }
+	}
 
-    return fields->timestamp;
+	return fields->timestamp;
 }
 
 /*

--- a/native/src/main/native/TrailDBTrail.c
+++ b/native/src/main/native/TrailDBTrail.c
@@ -48,13 +48,13 @@ JNIEXPORT jstring JNICALL Java_traildb_TrailDBTrail_getItem(JNIEnv *env, jobject
 
 	// Retrieve fields pointer
 
-    fields = (TrailDBTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBTrail_fields);
+	fields = (TrailDBTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBTrail_fields);
 
 	// Retrieve items pointer
 
 	items = (tdb_item *) fields->items;
 
-    if (items == 0L) {
+	if (items == 0L) {
 		exc = (*env)->FindClass(env, "java/lang/IllegalStateException");
 		if (exc == NULL) {
 			/* Could not find the exception - We are in so much trouble right now */
@@ -62,7 +62,7 @@ JNIEXPORT jstring JNICALL Java_traildb_TrailDBTrail_getItem(JNIEnv *env, jobject
 		}
 		(*env)->ThrowNew(env, exc, "Cursor is not pointing at an event");
 		return NULL;
-    }
+	}
 
 	if (index >= fields->num_items || index < 0) {
 		exc = (*env)->FindClass(env, "java/lang/IndexOutOfBoundsException");
@@ -100,9 +100,9 @@ JNIEXPORT jint JNICALL Java_traildb_TrailDBTrail_getNumItems(JNIEnv *env, jobjec
 
 	// Retrieve fields pointer
 
-    fields = (TrailDBTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBTrail_fields);
+	fields = (TrailDBTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBTrail_fields);
 
-    if (fields->items == 0L) {
+	if (fields->items == 0L) {
 		exc = (*env)->FindClass(env, "java/lang/IllegalStateException");
 		if (exc == NULL) {
 			/* Could not find the exception - We are in so much trouble right now */
@@ -110,9 +110,9 @@ JNIEXPORT jint JNICALL Java_traildb_TrailDBTrail_getNumItems(JNIEnv *env, jobjec
 		}
 		(*env)->ThrowNew(env, exc, "Cursor is not pointing at an event");
 		return 0;
-    }
+	}
 
-    return fields->num_items;
+	return fields->num_items;
 }
 
 JNIEXPORT jlong JNICALL Java_traildb_TrailDBTrail_getTimestamp(JNIEnv *env, jobject obj) {
@@ -122,9 +122,9 @@ JNIEXPORT jlong JNICALL Java_traildb_TrailDBTrail_getTimestamp(JNIEnv *env, jobj
 
 	// Retrieve fields pointer
 
-    fields = (TrailDBTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBTrail_fields);
+	fields = (TrailDBTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBTrail_fields);
 
-    if (fields->items == 0L) {
+	if (fields->items == 0L) {
 		exc = (*env)->FindClass(env, "java/lang/IllegalStateException");
 		if (exc == NULL) {
 			/* Could not find the exception - We are in so much trouble right now */
@@ -132,9 +132,9 @@ JNIEXPORT jlong JNICALL Java_traildb_TrailDBTrail_getTimestamp(JNIEnv *env, jobj
 		}
 		(*env)->ThrowNew(env, exc, "Cursor is not pointing at an event");
 		return 0;
-    }
+	}
 
-    return fields->timestamp;
+	return fields->timestamp;
 }
 
 JNIEXPORT void JNICALL Java_traildb_TrailDBTrail_native_1getTrail(JNIEnv *env, jobject obj, jlong trail_id) {
@@ -142,7 +142,7 @@ JNIEXPORT void JNICALL Java_traildb_TrailDBTrail_native_1getTrail(JNIEnv *env, j
 
 	// Retrieve fields pointer
 
-    fields = (TrailDBTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBTrail_fields);
+	fields = (TrailDBTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBTrail_fields);
 
 	// Get trail from cursor
 
@@ -158,7 +158,7 @@ JNIEXPORT jlong JNICALL Java_traildb_TrailDBTrail_getTrailLength(JNIEnv *env, jo
 
 	// Retrieve fields pointer
 
-    fields = (TrailDBTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBTrail_fields);
+	fields = (TrailDBTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBTrail_fields);
 
 	// Get trail length
 
@@ -178,7 +178,7 @@ JNIEXPORT void JNICALL Java_traildb_TrailDBTrail_setEventFilter(JNIEnv *env, job
 
 	// Retrieve fields pointer
 
-    fields = (TrailDBTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBTrail_fields);
+	fields = (TrailDBTrailFields *) (*env)->GetLongField(env, obj, FID_traildb_TrailDBTrail_fields);
 
 	// Set the event filter on the cursor
 
@@ -235,7 +235,7 @@ JNIEXPORT jobject JNICALL Java_traildb_TrailDBTrail_next(JNIEnv *env, jobject ob
 	fields->num_items = (long) event->num_items;
 	fields->items = (long) event->items;
 
-    // Return self for convenience
+	// Return self for convenience
 
 	return obj;
 }
@@ -267,7 +267,7 @@ JNIEXPORT jobject JNICALL Java_traildb_TrailDBTrail_peek(JNIEnv *env, jobject ob
 	fields->num_items = (long) event->num_items;
 	fields->items = (long) event->items;
 
-    // Return self for convenience
+	// Return self for convenience
 
 	return obj;
 }

--- a/native/src/main/native/traildb-java-static.h
+++ b/native/src/main/native/traildb-java-static.h
@@ -1,0 +1,17 @@
+
+typedef struct TrailDBMultiTrailFields {
+	long timestamp;
+	long num_items;
+	long items;
+	long db;
+	long multi_cur;
+	long cursor_idx;
+} TrailDBMultiTrailFields;
+
+typedef struct TrailDBTrailFields {
+	long timestamp;
+	long num_items;
+	long items;
+	long db;
+	long cur;
+} TrailDBTrailFields;


### PR DESCRIPTION
Rather than storing trail state in separate fields, store them all in a single struct. This drastically reduces the number of calls to Get/SetLongField. The drawback is that any method which uses these fields must now be native since it's difficult to access the members of a struct from Java.

@buremba Thanks for the suggestion. This PR compiles and passes the tests. Would you mind reviewing and running your benchmarks on it?